### PR TITLE
Cache Rust dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run tests
         run: cargo test
       - name: Install
-        run: cargo install --path .
+        run: cargo install --locked --path .
       # partially covered by tests/cli.rs, but this checks the shebang
       - name: Check output of hello example
         run: examples/hello.qn | git diff --no-index examples/hello.txt -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v1
+      - name: Get dependencies from cache
+        uses: Swatinem/rust-cache@v1
       - name: Install Tree-sitter CLI
         run: |
           TS_GH=https://github.com/tree-sitter/tree-sitter.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v1
       - name: Install Tree-sitter CLI
         run: |
           TS_GH=https://github.com/tree-sitter/tree-sitter.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -776,7 +776,7 @@ checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc",
 ]
 
@@ -787,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -798,9 +798,9 @@ checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
@@ -811,7 +811,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prerequisites:
 First install:
 
 ```sh
-cargo install --path .
+cargo install --locked --path .
 ```
 
 Then run an example:


### PR DESCRIPTION
The use of `--locked` here increases determinism, which helps caching by [making `cargo install` act more like `cargo build`](https://github.com/rust-lang/cargo/issues/7169). Prior to this PR, running `cargo install --locked --path .` gave these two warnings:
```
warning: package `pin-project-lite v0.2.4` in Cargo.lock is yanked in registry `crates.io`, consider running without --locked
warning: package `rand_core v0.6.1` in Cargo.lock is yanked in registry `crates.io`, consider running without --locked
```
So I ran these two commands to update `Cargo.lock`:
```sh
cargo update -p pin-project-lite
cargo update -p rand_core:0.6.1
```