### PR TITLE
Fix VS Code release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ dependencies = [
 
 [[package]]
 name = "quench"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quench"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Sam Estep <sam@samestep.com>"]
 edition = "2018"
 description = "A programming language."

--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -27,9 +27,8 @@ Next, from VS Code, press F5 to open a new window with this extension loaded.
 Open a Quench source file (such as `examples/hello.qn` from this repository) and
 observe the syntax highlighting:
 
-![screnshot of hello.qn in VS Code][hello.png]
+![screnshot of hello.qn in VS Code](hello.png)
 
-[hello.png]: /editors/code/hello.png
 [node]: https://github.com/nvm-sh/nvm#install--update-script
-[quench]: /README.md
+[quench]: https://github.com/samestep/quench
 [vs code]: https://code.visualstudio.com/download

--- a/editors/code/package-lock.json
+++ b/editors/code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quench",
-  "version": "0.0.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "quench",
-      "version": "0.0.1",
+      "version": "0.1.2",
       "dependencies": {
         "vscode-languageclient": "^7.0.0"
       },

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -2,7 +2,7 @@
   "name": "quench",
   "displayName": "Quench",
   "description": "",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "publisher": "samestep",
   "repository": "github:samestep/quench",
   "engines": {

--- a/tests/goldenfiles/help.txt
+++ b/tests/goldenfiles/help.txt
@@ -1,4 +1,4 @@
-quench 0.1.1
+quench 0.1.2
 A programming language.
 
 USAGE:

--- a/tree-sitter-quench/package-lock.json
+++ b/tree-sitter-quench/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tree-sitter-quench",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "devDependencies": {
         "tree-sitter-cli": "^0.17"
       }

--- a/tree-sitter-quench/package.json
+++ b/tree-sitter-quench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-quench",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "",
   "devDependencies": {
     "tree-sitter-cli": "^0.17"


### PR DESCRIPTION
While #13 fixed the crates.io release for version 0.1.1, trying to run `vsce publish` from within `editors/code` now gives this error:

```
 ERROR  Images in README.md must come from an HTTPS source: /editors/code/hello.png
```

This PR attempts to fix that for version 0.1.2, now that I know that I can apparently [run `vsce package`](https://github.com/microsoft/vscode-vsce/issues/192#issuecomment-315746811) somewhat analogously to `cargo publish --dry-run`.

When I published v0.0.1 of the VS Code extension, I used this sequence of commands:

```sh
cd editors/code
npm install
vsce publish --baseImagesUrl='https://github.com/samestep/quench/blob/v0.1.0/editors/code'
```

The specific `--baseImagesUrl` I passed is incorrect, but it does seem to be necessary since I use relative links in `editors/code/README.md`. However, apparently the change to `editors/code/README.md` actually broke this approach, because currently, the above error message even occurs when passing `--baseImagesUrl`. This PR corrects the problem by changing the `hello.png` link back to the way it was, and also fixes the link for Quench itself.

The sequence of commands for publishing version 0.1.2 of the VS Code extension should look like this:

```sh
cd editors/code
npm install
npm run compile
vsce publish --baseImagesUrl='https://raw.githubusercontent.com/samestep/quench/v0.1.2/editors/code'
```