### PR TITLE
Fix repository link for VS Code extension

### DIFF
--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -4,7 +4,11 @@
   "description": "",
   "version": "0.1.2",
   "publisher": "samestep",
-  "repository": "github:samestep/quench",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/samestep/quench.git",
+    "directory": "editors/code"
+  },
   "engines": {
     "vscode": "^1.53.0"
   },


### PR DESCRIPTION
Apparently, even though [`npm` supports the `github:user/repo` syntax](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository), the VS Code Marketplace just turns it into `https://github.com/github:user/repo.git`, which 404's. This PR tries to fix the problem by using the more general syntax.